### PR TITLE
fix bug. extra "-data" was being appended to az blob storage container path in WaterData

### DIFF
--- a/src/fluvius.py
+++ b/src/fluvius.py
@@ -190,7 +190,7 @@ class WaterData:
                                 'account_key':storage_options['account_key']}
         self.connection_string = storage_options['connection_string']
         self.filesystem = 'az'
-        self.station_path = f'{self.container}-data/stations'
+        self.station_path = f'{self.container}/stations'
         self.station = {}
 
     def get_available_station_list(self):


### PR DESCRIPTION
Prior to the change I made for this PR, this:
```python
itvdb = WaterData("ana", "ana-data", storage_options)
itvdb.get_source_df()
```
worked, but when trying to get the available station list:
```python
>>> itvdb.get_available_station_list()
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/azure/storage/blob/aio/_list_blobs_helper.py", line 71, in _get_next_cb
    return await self._command(
  File "/usr/local/lib/python3.8/dist-packages/azure/storage/blob/_generated/aio/operations/_container_operations.py", line 1556, in list_blob_hierarchy_segment
    map_error(status_code=response.status_code, response=response, error_map=error_map)
  File "/usr/local/lib/python3.8/dist-packages/azure/core/exceptions.py", line 105, in map_error
    raise error
azure.core.exceptions.ResourceNotFoundError: Operation returned an invalid status 'The specified container does not exist.'
```

This is because `station_path` was being set to `f'{self.container}-data/stations'`, which resulted in a station path of `'ana-data-data/stations'`.

Everything seems to be working now, but put this in a PR to make sure that I'm not breaking anything downstream. cc @tonychang-cspinc 

