### PR TITLE
morphological operators for post-processing water masks

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -14,6 +14,7 @@ import matplotlib.pyplot as plt
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics import mean_squared_error, r2_score
 import matplotlib.pyplot as plt
+from scipy.ndimage.filters import generic_filter as gf
 
 def train_test_validate_split(df, proportions, part_colname = "partition"):
     """
@@ -316,3 +317,50 @@ def plot_obs_predict(obs_pred, title, savefig=False, outfn=""):
             facecolor="#FFFFFF",
             dpi=150
         )
+
+def denoise(image, operation = "erosion", kernel_size = 3, iterations = 1):
+
+    """
+    Morphological operations
+
+    Keyword arguments:
+    image -- the image 
+    operation -- the morphological operators (default erosion)
+    kernel_size -- the size of the matrix with which image is convolved (default 3)
+    iterations -- the number of times the operator is applied (default 1)
+    """
+
+    operations = ["erosion", "dilation", "opening", "closing"]
+    if operation not in operations:
+        raise ValueError("Invalid operation type. Expected one of: %s" % operations)
+    if (kernel_size % 2) == 0:
+        raise ValueError("The kernel must be of odd size (e.g., 3, 5, 7)")
+
+    # Create a square matrix of size `kernel_size` as the kernel
+    kernel = np.ones((kernel_size, kernel_size), np.uint8)
+
+    def erode(image, kernel = kernel, iterations = iterations):
+        for _ in range(iterations):
+            image = gf(image, np.min, footprint = kernel)
+        return image
+
+    def dilate(image, kernel = kernel, iterations = iterations):
+        for _ in range(iterations):
+            image = gf(image, np.max, footprint=kernel)
+        return image
+
+    print("Performing %s" % operation)
+    if operation == "erosion":
+        return erode(image)
+    elif operation == "dilation":
+        return dilate(image)
+    elif operation == "opening": 
+        # opening: the dilation of the erosion
+        arr = dilate(erode(image))
+        arr[image != 1] = 0
+        return arr
+    else: 
+        # closing: the erosion of the dilation
+        arr = erode(dilate(image))
+        arr[image != 1] = 0
+        return arr


### PR DESCRIPTION
## Summary of changes

The function `denoise` implements morphological operations using focal operations (focal min's and max's). Operators include [erosion](https://en.wikipedia.org/wiki/Erosion_(morphology)), [dilation](https://en.wikipedia.org/wiki/Dilation_(morphology)), [opening](https://en.wikipedia.org/wiki/Opening_(morphology)), and [closing](https://en.wikipedia.org/wiki/Closing_(morphology)). 

In erosion a kernel is convolved with an image. Any `1` in the original image will be considered `1` in the resulting image only if all the pixels under the kernel are `1`, otherwise it becomes `0` (it's _eroded_). In dilation, a pixel becomes `1` if _at least_ one pixel under the kernel in the original image is `1`. In our case erosion shrinks water areas, while dilation grows them.

Although it is implemented, the dilation operator is not likely to have application in this work. It would make our training samples even messier / noisier by growing the water pixels into the adjacent non-water landscape. The opening (the dilation of an erosion) and closing (the erosion of a dilation) operators involve an additional masking step, in which all pixels that are NOT considered water in the original 'io-lulc' image are set to `0`, no matter what the operator says.

## Future directions
- Implement a different kernel shape (e.g., circular)
- Make `kernel_size` and `iterations` arguments flexible, such that an opening operation can accomodate an erosion of size (or iterations) X, followed by dilation of size (or iterations) Y.
- Use image statistics (e.g., the ratio of water to non-water pixels) to inform decisions about the type of operator or its arguments